### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 # Install required system packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
-    libwebp6 \
+    libwebp7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
TLDR:
_- libwebp6 --> libwebp7_

-- 

Hi Greg,

I've been testing your fixes and they work. I only ran into 1 error while trying to deploy to Google Cloud Run. It wouldn't work with libwebp6, because it couldn't find the packager. But it did work with libwep7. So I think you upgrade that in your dockerfile.

With that, i managed to get great Webp-screenshots. Thanks

To do my part, i just created this pull request. 
